### PR TITLE
feat: fixed banner and first banner too

### DIFF
--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -3,7 +3,7 @@ import { ReactNode, type ReactElement } from 'react'
 export const Banner = ({ children }: { children: ReactNode }): ReactElement => {
 
   return (
-    <div className="relative w-full h-full min-h-[900px] flex flex-col items-center overflow-hidden">
+    <div className="relative w-full h-full min-h-[950px] flex flex-col items-center overflow-hidden">
       {
         children
       }

--- a/src/components/home/Banner2.tsx
+++ b/src/components/home/Banner2.tsx
@@ -3,8 +3,8 @@ import { type ReactElement } from 'react'
 export const Banner2 = (): ReactElement => {
     return (
         <div className="relative border h-[900px] w-full grid grid-cols-3">
-            <div className="col-span-2 relative w-full flex justify-center items-center overflow-hidden">
-                <img src='https://res.cloudinary.com/maulight/image/upload/v1732918809/e-commerce/banner_2.webp' className='w-full ' />
+            <div className="col-span-2 relative w-full flex justify-center items-center">
+                <img src='https://res.cloudinary.com/maulight/image/upload/v1732918809/e-commerce/banner_2.webp' className='h-full object-cover' />
             </div>
             <div className='col-span-1 flex justify-center items-center bg-[#9ed6f7]'>
                 <h1 className='absolute right-[12%] neue text-[42px] animated-background bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 inline-block text-transparent bg-clip-text'>Surreal Collection</h1>

--- a/src/components/home/BannerContent.tsx
+++ b/src/components/home/BannerContent.tsx
@@ -4,14 +4,14 @@ import { fadeIn } from '@/utils/functions'
 
 export const BannerContent = ({ children }: { children: ReactNode }) => {
     return (
-        <div className="w-full h-full flex flex-col justify-start items-center">
-            <div className="h-[25%]"></div>
+        <div className="w-full h-full flex flex-col justify-start items-center pb-5">
+            <div className="h-[18%]"></div>
             <div className="flex flex-col">
                 <motion.h1
                     variants={fadeIn('top', 0.2)}
                     initial={'hidden'}
                     whileInView={'show'}
-                    className='aktiv text-[240px] leading-none uppercase animated-background bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 inline-block text-transparent bg-clip-text z-10'>Emotions</motion.h1>
+                    className='text-[240px] leading-none uppercase animated-background bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 inline-block text-transparent bg-clip-text z-10'>Emotions</motion.h1>
                 <div
                     className="w-full flex justify-between mt-2 px-5 z-20">
                     <p className='text-[16px] neue text-[#ffffff] z-10 uppercase'>Captured</p>
@@ -19,8 +19,8 @@ export const BannerContent = ({ children }: { children: ReactNode }) => {
                     <p className='text-[16px] neue text-[#ffffff] z-10 uppercase'>Time</p>
                 </div>
             </div>
-            <div className="grow"></div>
-            <div className="w-full flex justify-end pb-5 z-20">
+            <div className="grow border"></div>
+            <div className="w-full flex justify-end z-20">
                 {
                     children
                 }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -44,12 +44,12 @@ function Home() {
                     <section className='relative w-full flex flex-col justify-center items-center overflow-y-scroll'>
                         <div className="w-full overflow-scroll scrollbar-hide flex flex-col">
                             <Banner>
-                                <div className="w-[1440px] h-[900px] flex justify-center items-center bg-[#fdfdfd] overflow-hidden">
+                                <div className="w-full max-w-[1440px] h-[950px] flex justify-center items-center bg-[#fdfdfd] overflow-hidden">
                                     <BannerContent>
                                         <PriceCard product={product} />
                                     </BannerContent>
-                                    <img src='https://res.cloudinary.com/maulight/image/upload/v1732922082/e-commerce/kx2betzo07jrpgq9i077.webp' alt="banner" className='absolute -bottom-32 w-full object-none object-bottom z-10' />
-                                    <img src={product.image} alt="banner" className='absolute -bottom-32 w-full object-none object-bottom z-0' />
+                                    <img src='https://res.cloudinary.com/maulight/image/upload/v1732922082/e-commerce/kx2betzo07jrpgq9i077.webp' alt="banner" className='absolute  w-full h-full object-none object-bottom z-10' />
+                                    <img src={product.image} alt="banner" className='absolute  w-full h-full object-none object-bottom z-0' />
                                 </div>
                             </Banner>
                             <Banner2 />


### PR DESCRIPTION
This pull request includes several updates to the `src/components/home` and `src/routes` directories to improve the layout and styling of the `Banner`, `Banner2`, and `BannerContent` components, as well as adjustments to the `Home` route. The most important changes include modifying the dimensions and styling of various elements to enhance the visual presentation.

Styling and layout improvements:

* [`src/components/home/Banner.tsx`](diffhunk://#diff-2157d3022e5b969733068fa2ec652e8e6346ee88b6c7d49d239a71a45ede4913L6-R6): Increased the minimum height of the `Banner` component from `900px` to `950px`.
* [`src/components/home/Banner2.tsx`](diffhunk://#diff-5a9491d03b5dc3f88f724c120be52becbb0a082b3fe05516ed802acc3d74453bL6-R7): Adjusted the `img` element to use `h-full` and `object-cover` classes for better image scaling.
* [`src/components/home/BannerContent.tsx`](diffhunk://#diff-4de9c9461fb0e686f5ebd7999203060ece40abe40817c4d135dc0fd8a0a74d45L7-R23): Added padding to the bottom of the container and modified the height of the top spacer. Removed unnecessary classes from the `motion.h1` element and added a border to the growing spacer.
* [`src/routes/Home.tsx`](diffhunk://#diff-b653d5e501fd54c4c1d61e1dc3f73e689242584b7037f41557f326bb3f6a2480L47-R52): Updated the `Banner` container to use `w-full max-w-[1440px]` for better responsiveness and adjusted the image elements to use `w-full h-full` for consistent sizing.both had issues with covering the space available and composition