### PR TITLE
feat: added recoil state in product list render

### DIFF
--- a/src/hooks/useFetchProductList.tsx
+++ b/src/hooks/useFetchProductList.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { atom, useSetRecoilState } from 'recoil';
+import { getAllProductsAsync } from '@/features/products/productsSlice';
+import { AppDispatch } from '@/store/store'
+import { ProductProps } from '@/utils/types';
+
+const productsListState = atom<ProductProps[]>({
+    key: 'ProductList',
+    default: []
+})
+
+export const useFetchProducts = (currentPage: number, pageSize: number) => {
+    const dispatch: AppDispatch = useDispatch()
+    const setProducts = useSetRecoilState(productsListState)
+
+    useEffect(() => {
+        const fetchProducts = async () => {
+            const { payload } = await dispatch(getAllProductsAsync())
+            setProducts(payload.products.slice(0, currentPage * pageSize))
+        }
+
+        fetchProducts()
+    }, [dispatch, setProducts, currentPage, pageSize])
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter as Router } from 'react-router-dom'
 import { Provider } from 'react-redux'
+import { RecoilRoot } from 'recoil'
 
 import store from './store/store.ts'
 import App from './App.tsx'
@@ -20,7 +21,9 @@ root.render(
 
   <Router>
     <Provider store={store}>
-      <App />
+      <RecoilRoot>
+        <App />
+      </RecoilRoot>
     </Provider>
   </Router>
 )


### PR DESCRIPTION
This pull request includes significant changes to the state management of the `ItemsTable` component by transitioning from Redux to Recoil. The most important changes include the removal of Redux-related code, the introduction of Recoil atoms and selectors, and the addition of a custom hook for fetching products.

State management transition:

* [`src/components/dashboard/ItemsTable.tsx`](diffhunk://#diff-5adef102fc8f4f3922e7a6e5d59b1b9bfac06202e7c212fc6b04d626e89b125dL1-R54): Removed Redux imports and replaced them with Recoil imports. Introduced `productsListState`, `currentPageState`, and `paginatedProductsSelector` atoms and selectors to manage state. Added a `loadMore` function and a "Load More" button to handle pagination.
* [`src/hooks/useFetchProductList.tsx`](diffhunk://#diff-b029698b1f8b6f82bfd87f27e529e6e971220f9875bf1aa77bb1bec60cf32549R1-R25): Created a new custom hook `useFetchProducts` to fetch products using Redux dispatch and set the Recoil state.

Integration of Recoil:

* [`src/main.tsx`](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811R7): Added `RecoilRoot` to the application root to provide Recoil state management. [[1]](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811R7) [[2]](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811R24-R26)in admin dashboard