### PR TITLE
Sym 50 add recoil to home collection components

### DIFF
--- a/src/components/dashboard/ItemsTable.tsx
+++ b/src/components/dashboard/ItemsTable.tsx
@@ -1,21 +1,12 @@
 import { type ReactNode } from 'react'
-import { atom, selector, useRecoilValue, useSetRecoilState } from 'recoil'
+import { selector, useRecoilValue, useSetRecoilState } from 'recoil'
+import { currentPageState, productsListState } from '@/utils/recoil'
+import { useFetchProducts } from '@/hooks/useFetchProductList'
 
 import DashboardCard from './DashboardCard'
 import { ProductProps } from '@/utils/types'
-import { useFetchProducts } from '@/hooks/useFetchProductList'
 
 const pageSize = 10
-
-const productsListState = atom<ProductProps[]>({
-    key: 'ProductList',
-    default: []
-})
-
-const currentPageState = atom<number>({
-    key: 'currentPageState',
-    default: 1
-})
 
 const paginatedProductsSelector = selector({
     key: 'paginatedProductsSelector',

--- a/src/hooks/useFetchProductList.tsx
+++ b/src/hooks/useFetchProductList.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
-import { atom, useSetRecoilState } from 'recoil';
-import { getAllProductsAsync } from '@/features/products/productsSlice';
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import { atom, useRecoilValue, useSetRecoilState } from 'recoil'
+import { getAllProductsAsync } from '@/features/products/productsSlice'
 import { AppDispatch } from '@/store/store'
 import { ProductProps } from '@/utils/types';
+import { currentPageState } from '@/utils/recoil';
 
 const productsListState = atom<ProductProps[]>({
     key: 'ProductList',
@@ -22,4 +23,30 @@ export const useFetchProducts = (currentPage: number, pageSize: number) => {
 
         fetchProducts()
     }, [dispatch, setProducts, currentPage, pageSize])
+}
+
+export const infiniteScrollFetch = () => {
+    const dispatch: AppDispatch = useDispatch()
+    const setProducts = useSetRecoilState(productsListState)
+    const setCurrentPage = useSetRecoilState(currentPageState)
+    const currentPage = useRecoilValue(currentPageState)
+
+    useEffect(() => {
+        const fetchProducts = async () => {
+            const { payload } = await dispatch(getAllProductsAsync())
+            setProducts((prevProducts) => [...prevProducts, ...payload.products])
+        }
+
+        fetchProducts()
+    }, [dispatch, setProducts, currentPage])
+
+    useEffect(() => {
+        const handleScroll = () => {
+            if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight) return
+            setCurrentPage((prevPage) => prevPage + 1)
+        }
+
+        window.addEventListener('scroll', handleScroll)
+        return () => window.removeEventListener('scroll', handleScroll)
+    }, [setCurrentPage])
 }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -14,13 +14,30 @@ import video from '@/assets/video/Error.webm'
 //* Types
 import { ProductProps, StoreProps } from "@/utils/types"
 import { getAllProductsAsync } from "@/features/products/productsSlice"
+import { selector, useRecoilValue } from "recoil"
+import { currentPageState, productsListState } from "@/utils/recoil"
+import { infiniteScrollFetch } from "@/hooks/useFetchProductList"
 
+const pageSize = 7
+
+const paginatedProductsSelector = selector({
+    key: 'paginatedProductsSelector',
+    get: async ({ get }) => {
+        const products = get(productsListState)
+        const currentPage = get(currentPageState)
+        return products.slice(0, currentPage * pageSize)
+    }
+})
 
 function Home() {
     const dispatch = useDispatch<AppDispatch>()
-    const products = useSelector((state: StoreProps) => state.inventory.products)
     const isLoading = useSelector((state: StoreProps) => state.homeCollection.collectionIsLoading)
     const hasError = useSelector((state: StoreProps) => state.homeCollection.collectionHasError)
+
+    const products = useRecoilValue(paginatedProductsSelector)
+
+    infiniteScrollFetch()
+
     const product = products[0]
 
     const collection: ProductProps[] = products.slice(1)

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -3,13 +3,13 @@ import { AppDispatch } from "@/store/store"
 import { useDispatch, useSelector } from "react-redux"
 
 //* Components
+import video from '@/assets/video/Error.webm'
 import { Banner } from "@/components/home/Banner"
 import { Banner2 } from "@/components/home/Banner2"
 import { PriceCard } from "@/components/common/PriceCard"
 import HomeSkeleton from "@/components/home/HomeSkeleton"
 import { ProductCard } from "@/components/common/ProductCard"
 import { BannerContent } from "@/components/home/BannerContent"
-import video from '@/assets/video/Error.webm'
 
 //* Types
 import { ProductProps, StoreProps } from "@/utils/types"

--- a/src/utils/recoil.ts
+++ b/src/utils/recoil.ts
@@ -1,0 +1,12 @@
+import { atom } from "recoil"
+import { ProductProps } from "./types"
+
+export const productsListState = atom<ProductProps[]>({
+    key: 'ProductList',
+    default: []
+})
+
+export const currentPageState = atom<number>({
+    key: 'currentPageState',
+    default: 1
+})


### PR DESCRIPTION
This pull request includes several important changes to improve state management and implement infinite scrolling in the product list. The changes involve refactoring the Recoil state management, introducing a new `infiniteScrollFetch` function, and updating the `Home` component to use these new features.

### State Management Refactor:
* [`src/components/dashboard/ItemsTable.tsx`](diffhunk://#diff-5adef102fc8f4f3922e7a6e5d59b1b9bfac06202e7c212fc6b04d626e89b125dL2-L19): Removed the local definitions of `productsListState` and `currentPageState`, and imported them from `src/utils/recoil` instead.
* [`src/utils/recoil.ts`](diffhunk://#diff-d2f966af5c5e1da80fa57cb3f7a6f76e151fa3f58122d5ab61c4e723db04bf4cR1-R12): Added new Recoil atoms `productsListState` and `currentPageState` to manage the product list and current page state globally.

### Infinite Scrolling Implementation:
* [`src/hooks/useFetchProductList.tsx`](diffhunk://#diff-b029698b1f8b6f82bfd87f27e529e6e971220f9875bf1aa77bb1bec60cf32549R27-R52): Introduced a new `infiniteScrollFetch` function to handle fetching additional products when the user scrolls to the bottom of the page.
* [`src/routes/Home.tsx`](diffhunk://#diff-b653d5e501fd54c4c1d61e1dc3f73e689242584b7037f41557f326bb3f6a2480R6-R40): Updated the `Home` component to use the new `infiniteScrollFetch` function and the `paginatedProductsSelector` to manage the paginated product list.